### PR TITLE
Possible fix for comments displaying "in a few seconds"

### DIFF
--- a/src/components/feed/comments/index.js
+++ b/src/components/feed/comments/index.js
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import { customLayout } from '../../mixins'
 import Moment from 'react-moment'
 import { Link } from 'react-router-dom'
+import moment from 'moment'
 class CommentBox extends Component {
   constructor(props) {
     super(props)
@@ -49,7 +50,13 @@ class CommentBox extends Component {
                           <Link to={`/profile/${comment.user_id}`}>
                             {comment.username}{' '}
                             <span className='comment-date'>
-                              <Moment fromNow>{comment.created_at}</Moment>:
+                              <Moment fromNow>
+                                {moment(comment.created_at).subtract(
+                                  '30',
+                                  'seconds'
+                                )}
+                              </Moment>
+                              :
                             </span>
                           </Link>
                         </h2>
@@ -70,7 +77,13 @@ class CommentBox extends Component {
                           <Link to={`/profile/${comment.user_id}`}>
                             {comment.username}{' '}
                             <span className='comment-date'>
-                              <Moment fromNow>{comment.created_at}</Moment>:
+                              <Moment fromNow>
+                                {moment(comment.created_at).subtract(
+                                  '30',
+                                  'seconds'
+                                )}
+                              </Moment>
+                              :
                             </span>
                           </Link>
                         </h2>


### PR DESCRIPTION
# Description
After you post a comment on feed, it shows "in a few seconds" for the date. I believe this is due to the time it takes for the server to send the response back because it does not happen locally.

Please include a summary of the change and a link to which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status

- [ ] Complete, tested, ready to review and merge
- [ ] Work-in-Progress, PR is for discussion/feedback

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] There are no merge conflicts
- [ ] I have made corresponding changes to the documentation
