### PR TITLE
removing the usage of the socket listeners on comments

### DIFF
--- a/src/App/index.js
+++ b/src/App/index.js
@@ -41,24 +41,6 @@ const App = props => {
         socket.on('join', data => {
           receivingNotifications(data)
         })
-        // socket is listening on comments event & will receive a msg obj
-        socket.on('comments', msg => {
-          // msg obj contains properties of content, action, post_id, user_id, username, created_at, & updated_at
-          switch (msg.action) {
-            // when action type === destroy
-            case 'destroy':
-              // invoke action creator deleteComment & pass in msg obj
-              deleteComment(msg)
-              break
-            // when action type === create
-            case 'create':
-              // invoke action creator createComment & pass in msg obj
-              createComment(msg)
-              break
-            default:
-              break
-          }
-        })
       }
     })
     return () => {

--- a/src/App/index.js
+++ b/src/App/index.js
@@ -24,13 +24,7 @@ const Success = lazy(() => import('pages/Success'))
 const NoMatch = lazy(() => import('pages/NoMatch'))
 
 const App = props => {
-  const {
-    auth,
-    fetchAuth,
-    receivingNotifications,
-    createComment,
-    deleteComment,
-  } = props
+  const { auth, fetchAuth, receivingNotifications } = props
   // initial fetchAuth on browser mount
   useEffect(() => {
     fetchAuth().then(user => {
@@ -88,7 +82,6 @@ App.propTypes = {
   auth: PropTypes.any,
   fetchAuth: PropTypes.func.isRequired,
   receivingNotifications: PropTypes.func.isRequired,
-  createComment: PropTypes.func.isRequired,
 }
 
 const Container = styled.div`

--- a/src/App/store/appActions.js
+++ b/src/App/store/appActions.js
@@ -32,6 +32,8 @@ export const createComment = commentData => async dispatch => {
 }
 
 export const deleteComment = commentData => async dispatch => {
+  const { id } = commentData
+  const resp = await axios.delete(`/comments/${id}`)
   dispatch({ type: types.DELETE_COMMENT, payload: commentData })
 }
 

--- a/src/App/store/appActions.js
+++ b/src/App/store/appActions.js
@@ -27,7 +27,8 @@ export const fetchNotifications = notifications => ({
 
 export const createComment = commentData => async dispatch => {
   const { data } = await axios.post('/comments', commentData)
-  dispatch({ type: types.CREATE_COMMENT, payload: data[0] })
+  const { username } = commentData
+  dispatch({ type: types.CREATE_COMMENT, payload: { ...data[0], username } })
 }
 
 export const deleteComment = commentData => async dispatch => {

--- a/src/containers/Feed/index.js
+++ b/src/containers/Feed/index.js
@@ -13,7 +13,6 @@ import FeedPlaceholder from './Post/FeedPlaceholder'
 import { handlePostReactions, createComment } from 'App/store/appActions'
 const Feed = props => {
   const {
-    auth,
     user,
     tag,
     posts,
@@ -31,7 +30,7 @@ const Feed = props => {
       const comment = {
         action: 'create',
         content: body,
-        user_id: auth.id,
+        user_id: user.id,
         post_id: post_id,
         username: user.username,
         postOwnerId,
@@ -93,14 +92,13 @@ const Feed = props => {
 }
 
 // export default Feed
-const mapStateToProps = ({ auth, user }) => ({ auth, user })
+const mapStateToProps = ({ user }) => ({ user })
 
 export default connect(mapStateToProps, { handlePostReactions, createComment })(
   withRouter(Feed)
 )
 
 Feed.propTypes = {
-  auth: PropTypes.any,
   user: PropTypes.shape({
     username: PropTypes.string.isRequired,
     profile_picture: PropTypes.string.isRequired,

--- a/src/containers/Feed/index.js
+++ b/src/containers/Feed/index.js
@@ -10,7 +10,11 @@ import InfiniteScroll from 'react-infinite-scroll-component'
 import ScrollToTopOnMount from 'components/Utils/ScrollToTopOnMount'
 import PostContainer from './Post/'
 import FeedPlaceholder from './Post/FeedPlaceholder'
-import { handlePostReactions, createComment } from 'App/store/appActions'
+import {
+  handlePostReactions,
+  createComment,
+  deleteComment,
+} from 'App/store/appActions'
 const Feed = props => {
   const {
     user,
@@ -22,6 +26,7 @@ const Feed = props => {
     fetchMoreTagFeed,
     handlePostReactions,
     createComment,
+    deleteComment,
   } = props
 
   const handleSubmit = (event, post_id, comment, postOwnerId) => {
@@ -40,11 +45,7 @@ const Feed = props => {
   }
 
   const handleDeleteComment = (comment_id, post_id) => {
-    socket.emit('comments', {
-      action: 'destroy',
-      comment_id: comment_id,
-      post_id: post_id,
-    })
+    deleteComment({ id: comment_id, post_id })
   }
 
   const handleReactionClick = data => {
@@ -94,9 +95,11 @@ const Feed = props => {
 // export default Feed
 const mapStateToProps = ({ user }) => ({ user })
 
-export default connect(mapStateToProps, { handlePostReactions, createComment })(
-  withRouter(Feed)
-)
+export default connect(mapStateToProps, {
+  handlePostReactions,
+  createComment,
+  deleteComment,
+})(withRouter(Feed))
 
 Feed.propTypes = {
   user: PropTypes.shape({


### PR DESCRIPTION
# Description
**Issue**
> There is a bug where commenting doesn't immediately update ... this only happens when you login and immediately comment. if you hard refresh you will see the comment and then all other comments will update immediately.

I decide having real time comments show & delete on users feed was causing too many bugs and wasn't worth keeping. The changes in the PR are all involving migrating from using the socket emitter functions from socket.io to using good ole axios methods. 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status

- [X] Complete, tested, ready to review and merge
- [ ] Work-in-Progress, PR is for discussion/feedback

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] There are no merge conflicts
- [ ] I have made corresponding changes to the documentation
